### PR TITLE
responsive media queries and calculated width based on percent.

### DIFF
--- a/src/app/components/game-board/game-board-square/game-board-square.component.scss
+++ b/src/app/components/game-board/game-board-square/game-board-square.component.scss
@@ -9,6 +9,11 @@
     transition: background-color 0.2s ease-out;
     padding: 0;
     display: block;
+    position:absolute; //hi again
+    top:0;
+    left:0;
+    bottom:0;
+    right:0;
     &.won {
         background-color: $color-blue;
     }

--- a/src/app/components/game-board/game-board.component.html
+++ b/src/app/components/game-board/game-board.component.html
@@ -4,8 +4,15 @@
     <img id="state-msg-img" *ngIf="gameState === EGameState.WON" src="./assets/trophy.svg" alt="winner image">
   </div>
 
-  <table class="game-board-table"
-    [ngClass]="{'wide': data.isWideBoard, 'won': gameState === EGameState.WON, 'lost': gameState === EGameState.LOST}">
+  <table
+    class="game-board-table"
+    [ngClass]="{
+      'wide': data.isWideBoard,
+      'won': gameState === EGameState.WON,
+      'lost': gameState === EGameState.LOST,
+      'large': data.isWideBoard
+    }"
+  >
     <thead>
       <tr>
         <td></td>
@@ -18,8 +25,14 @@
         <th class="game-board-axes">{{axesLabels.y[rowI]}}</th>
 
         <ng-container *ngFor="let square of boardSquaresArr; index as squareI">
-          <td *ngIf="squareI | matrixPipe : rowI : data.columns" class="game-board-row-square"
-            [ngClass]="{'large': data.isWideBoard}">
+          <td
+            *ngIf="squareI | matrixPipe : rowI : data.columns"
+            class="game-board-row-square"
+            [style]="{
+              width:''+squareWidthInPercent+'%',
+              paddingBottom: ''+squareWidthInPercent+'%'
+            }"
+            >
             <app-game-board-square [square]="square" [gameState]="gameState"
               (squareClickedEmit)="squareClicked(squareI, $event)">
             </app-game-board-square>

--- a/src/app/components/game-board/game-board.component.scss
+++ b/src/app/components/game-board/game-board.component.scss
@@ -23,7 +23,7 @@
 
 .game-board {
     transform: translateX(-10px);
-    max-width: 800px;
+    max-width: 1600px; //going big here
     margin: auto;
 
     &-axes {
@@ -36,23 +36,45 @@
     }
 
     &-table {
-        &.wide {
-            border-collapse: collapse;
-        }
-        &.won {
-            filter: blur(4px);
-        }
+      width:600px;
+      &.large {
+        width:1200px;
+      }
+      &.wide {
+         border-collapse: collapse;
+      }
+      &.won {
+          filter: blur(4px);
+      }
     }
 
     &-row-square {
         position: relative;
-        &.large {
-            height: 33px;
-            width: 33px;
-        }
-        &:not(.large) {
-            height: 44px;
-            width: 44px;
-        }
+        height:0; //bottom padding is calculated based on width so it's a great candidate here as we have no actual content in our cell.
+        // width: 44px;
+        //removed .large as computation moved to table now
     }
+}
+
+
+@media only screen and (max-width: 1000px) {
+  .game-board {
+    &-table {
+      width:700px;
+      &.large {
+        width:900px;
+      }
+    }
+  }
+}
+
+@media only screen and (max-width: 600px) {
+  .game-board {
+    &-table {
+      width:400px;
+      &.large {
+        width:400px;
+      }
+    }
+  }
 }

--- a/src/app/components/game-board/game-board.component.ts
+++ b/src/app/components/game-board/game-board.component.ts
@@ -23,6 +23,9 @@ export class GameBoardComponent implements OnInit {
   public boardSquaresArr: ISquareItem[];
   public shipsAmountsList: IShipsAmountsList[];
   public EGameState: typeof EGameState;
+  //will decide on width/padding-bottom (instead of height because our TD doesn't care about height.)
+  public squareWidthInPercent : number;
+
 
   @Output() gameStateChanged: EventEmitter<EGameState> = new EventEmitter<EGameState>();
   @Output() shipsAmountListChanged: EventEmitter<IShipsAmountsList[]> = new EventEmitter<IShipsAmountsList[]>();
@@ -55,6 +58,7 @@ export class GameBoardComponent implements OnInit {
     this.largestShipImg = 7;
     this.boardSquaresArr = [];
     this.shipsAmountsList = [];
+    this.squareWidthInPercent = 0; //init because ts is forcing me to.
 
     this._gameState = EGameState.PLAYING;
     this._gameData = {} as IGameLevelData;
@@ -69,6 +73,7 @@ export class GameBoardComponent implements OnInit {
   }
 
   private setGameLevel(): void {
+    this.squareWidthInPercent = 100/this.data.columns; //we don't care about rows because squares.
     this.data.amountOfSquares = this.data.rows * this.data.columns;
     this.data.isWideBoard = this.data.columns >= 20;
     this.rows = new Array(this.data.rows);
@@ -187,7 +192,7 @@ export class GameBoardComponent implements OnInit {
     }
 
     if (this.strikesCounter === this.data.amountOfShips) {
-      this.gameStateChanged.emit(EGameState.WON);      
+      this.gameStateChanged.emit(EGameState.WON);
     }
   }
 


### PR DESCRIPTION
This PR fixes the issue with square cells gaining too much height on responsive pages.

* squares are now calculated by percent of amount of columns.
* width control moved to table
* media queries to control different table width added

issues:
* current borders are still posing some issues - namely: table shaking when resizing in responsive view (not really an issue) and wide table with 30+ squares ( detailed below)
* in <500px views, the 2px borders are interfering with the already small squares. should be fixed separately in a media query.